### PR TITLE
mobile: fluid typography and layout, no breakpoints

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -18,7 +18,7 @@
 }
 
 html {
-  font-size: 14pt;
+  font-size: clamp(13px, 2.6vw, 18px);
 }
 
 body {
@@ -30,7 +30,7 @@ body {
 }
 
 body > * {
-  padding: 1rem;
+  padding: clamp(0.5rem, 2vw, 1rem);
 }
 
 body > header {
@@ -46,6 +46,11 @@ input, textarea {
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
+  max-width: 100%;
+}
+
+textarea {
+  min-height: clamp(8rem, 40vh, 20rem);
 }
 
 button {
@@ -56,7 +61,8 @@ button {
 
 body > header > section {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
   justify-content: space-between;
   align-items: baseline;
 }
@@ -74,6 +80,7 @@ body > main {
 
 body > main > section {
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -81,14 +88,15 @@ body > main > section {
 
 .posts {
   display: grid;
-  grid-template-columns: 48px 1fr;
-  gap: 1rem 0.75rem;
+  grid-template-columns: clamp(40px, 12vw, 56px) minmax(0, 1fr);
+  gap: clamp(0.5rem, 2vw, 1rem) 0.75rem;
   align-items: start;
 }
 
 .posts img {
-  width: 48px;
-  height: 48px;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: 4px;
 }
@@ -118,7 +126,8 @@ form {
 button {
   white-space: nowrap;
   letter-spacing: 1px;
-  padding: 0.25rem 0.5rem;
+  padding: 0.35rem 0.6rem;
+  min-height: 2rem;
 }
 
 pre {
@@ -127,6 +136,7 @@ pre {
   white-space: -pre-wrap;
   white-space: -o-pre-wrap;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
   line-height: 1.5;
   font-size: 0.875rem;
   max-height: 50rem;
@@ -163,7 +173,8 @@ a:link {
 .reaction button, .reaction a {
   background: none;
   border: 0px solid currentColor;
-  padding: 0;
+  padding: 0.15rem 0.25rem;
+  min-height: 1.75rem;
   cursor: pointer;
   opacity: 0.6;
   color: inherit;
@@ -190,7 +201,7 @@ a:link {
 
 .tag-preset {
   font-size: 0.75rem;
-  padding: 0.125rem 0.375rem;
+  padding: 0.2rem 0.45rem;
   background: none;
   border: 1px solid currentColor;
   border-radius: 0.25rem;
@@ -209,7 +220,7 @@ a:link {
 
 .filter-pill {
   font-size: 0.75rem;
-  padding: 0.125rem 0.375rem;
+  padding: 0.2rem 0.45rem;
   background: none;
   border: 1px solid currentColor;
   border-radius: 0.25rem;
@@ -230,4 +241,13 @@ h2 {
 a.thumb {
   -webkit-touch-callout: none;
   user-select: none;
+}
+
+.notify-enable {
+  position: fixed;
+  bottom: max(0.5rem, env(safe-area-inset-bottom));
+  right: max(0.5rem, env(safe-area-inset-right));
+  font-size: 0.75rem;
+  opacity: 0.7;
+  z-index: 10;
 }

--- a/server.tsx
+++ b/server.tsx
@@ -292,9 +292,8 @@ const SortToggle = ({ sort, baseHref, title }: { sort: string; baseHref: string;
     return `${base.pathname}?${p}`;
   };
   return (
-    <nav style="margin-bottom:0.5rem;display:flex;gap:0.5rem;align-items:baseline;justify-content:space-between;text-wrap:nowrap;">
+    <nav style="margin-bottom:0.5rem;display:flex;flex-wrap:wrap;gap:0.5rem 1rem;align-items:baseline;justify-content:space-between;">
       <span>{title}</span>
-      <span style="text-overflow:hidden;overflow:hidden;opacity:0.5;">{". ".repeat(100)}</span>
       <span style="font-size:0.85rem;">
         {["hot", "new", "top"].map((s, i) => (
           <Fragment key={s}>{i > 0 && " • "}{sort === s ? s : <a href={href(s)}>{s}</a>}</Fragment>
@@ -514,7 +513,7 @@ app.use("*", async (c, next) => {
       if (Notification.permission === "default") {
         const b = document.createElement("button");
         b.textContent = "🔔 enable notifications";
-        b.style.cssText = "position:fixed;bottom:0.5rem;right:0.5rem;font-size:0.75rem;opacity:0.7;z-index:10;";
+        b.className = "notify-enable";
         b.onclick = async () => { await Notification.requestPermission(); b.remove(); };
         document.body.appendChild(b);
       }
@@ -552,7 +551,7 @@ app.use("*", async (c, next) => {
         <body>
           <header>
             <section>
-              <a href="/" style="letter-spacing:10px;font-weight:700;width:100%;">▢ding</a>
+              <a href="/" style="letter-spacing:clamp(2px,2vw,10px);font-weight:700;width:100%;">▢ding</a>
               <a href="/o/new" style="letter-spacing:2px;font-size:0.875rem;opacity:0.8;"> +org </a>
               ${n
                 ? html`
@@ -1059,13 +1058,13 @@ app.get("/o/new", authed, (c) =>
       </p>
       <p style="font-size: 0.875rem; opacity: 0.8; margin-bottom: 1.5rem;">cost: $1/member/month.</p>
       <form method="post" action="/o/new" style="padding: 0;">
-        <div style="display:flex; gap:0.5rem; align-items:center;">
+        <div style="display:flex; flex-wrap:wrap; gap:0.5rem; align-items:center;">
           <input
             required
             pattern="^[0-9a-zA-Z_]{4,32}$"
             name="name"
             placeholder="org_name"
-            style="flex: 1; max-width: 300px; padding: 0.25rem 0.5rem; border-radius: 5px; border: 1px solid currentColor;"
+            style="flex: 1; padding: 0.25rem 0.5rem; border-radius: 5px; border: 1px solid currentColor;"
           />
           <button type="submit">create & subscribe</button>
         </div>
@@ -1217,14 +1216,14 @@ app.get("/o/:name", async (c) => {
             <form
               method="post"
               action={`/o/${org.name}/invite`}
-              style="padding: 0; display: flex; flex-direction: row; gap: 0.5rem;"
+              style="padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem;"
             >
               <input
                 required
                 type="email"
                 name="email"
                 placeholder="email"
-                style="flex: 1; max-width: 240px; padding: 0.25rem 0.5rem; border-radius: 5px; border: 1px solid currentColor;"
+                style="flex: 1; padding: 0.25rem 0.5rem; border-radius: 5px; border: 1px solid currentColor;"
               />
               <button type="submit">invite ($1/mo)</button>
             </form>


### PR DESCRIPTION
- root font-size and body padding scale with clamp()
- header/SortToggle nav wraps instead of horizontal-scrolling
- post grid thumbnail column uses clamp + minmax(0,1fr) to prevent overflow
- inputs drop fixed max-widths; forms wrap when crowded
- bigger touch targets on buttons, reactions, tag/filter pills
- textarea has fluid min-height so short viewports work
- notification button uses safe-area insets via .notify-enable class
- pre/posts get overflow-wrap so long URLs do not blow out columns